### PR TITLE
Rename macro

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -24,6 +24,9 @@ function(defineInterfaces)
     if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
       target_compile_options("${projName}CompileOptions"
                              INTERFACE -march=armv8-a)
+    elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch32")
+      target_compile_options("${projName}CompileOptions"
+                             INTERFACE -march=armv7-a -mfpu=neon)
     else()
       target_compile_options("${projName}CompileOptions"
                              INTERFACE -march=native)

--- a/include/ithread.h
+++ b/include/ithread.h
@@ -40,7 +40,7 @@
 
 #include <stdint.h>
 
-#define UNUSED(x) ((void) x)
+#define ITHREAD_UNUSED(x) ((void) x)
 
 typedef void *(*ThreadFxn)(void *);
 

--- a/src/ithread.c
+++ b/src/ithread.c
@@ -72,7 +72,7 @@ int32_t ithread_create(void *thread_handle, void *attribute, ThreadFxn strt, voi
   HANDLE *ppv_thread_handle;
   HANDLE  thread_handle_value;
 
-  UNUSED(attribute);
+  ITHREAD_UNUSED(attribute);
 
   if (0 == thread_handle)
     return -1;
@@ -94,7 +94,7 @@ int32_t ithread_join(void *thread_handle, void **val_ptr)
   HANDLE *ppv_thread_handle;
   HANDLE  thread_handle_value;
 
-  UNUSED(val_ptr);
+  ITHREAD_UNUSED(val_ptr);
 
   if (0 == thread_handle)
     return -1;
@@ -230,7 +230,7 @@ int32_t ithread_sem_init(void *sem, int32_t pshared, uint32_t value)
   HANDLE *sem_handle = (HANDLE *) sem;
   HANDLE  sem_handle_value;
 
-  UNUSED(pshared);
+  ITHREAD_UNUSED(pshared);
 
   if (0 == sem)
     return -1;
@@ -304,14 +304,14 @@ int32_t ithread_sem_destroy(void *sem)
 
 int32_t ithread_set_affinity(int32_t core_id)
 {
-  UNUSED(core_id);
+  ITHREAD_UNUSED(core_id);
 
   return 1;
 }
 
 void ithread_set_name(char *pc_thread_name)
 {
-  UNUSED(pc_thread_name);
+  ITHREAD_UNUSED(pc_thread_name);
 
   return;
 }
@@ -330,14 +330,14 @@ uint32_t ithread_get_mutex_lock_size(void)
 
 int32_t ithread_create(void *thread_handle, void *attribute, ThreadFxn strt, void *argument)
 {
-  UNUSED(attribute);
+  ITHREAD_UNUSED(attribute);
   return pthread_create((pthread_t *) thread_handle, NULL, strt, argument);
 }
 
 int32_t ithread_join(void *thread_handle, void **val_ptr)
 {
   pthread_t *pthread_handle = (pthread_t *) thread_handle;
-  UNUSED(val_ptr);
+  ITHREAD_UNUSED(val_ptr);
   return pthread_join(*pthread_handle, NULL);
 }
 
@@ -421,7 +421,7 @@ void ithread_set_name(char *pc_thread_name)
 #ifndef WIN32
 #ifndef QNX
 #ifndef IOS
-  UNUSED(pc_thread_name);
+  ITHREAD_UNUSED(pc_thread_name);
 #endif
 #endif
 #endif
@@ -443,7 +443,7 @@ int32_t ithread_set_affinity(int32_t core_id)
 
 #elif SYSCALL_AFFINITY
   int32_t i4_sys_res;
-  UNUSED(core_id);
+  ITHREAD_UNUSED(core_id);
 
   pid_t pid = gettid();
 
@@ -453,7 +453,7 @@ int32_t ithread_set_affinity(int32_t core_id)
     return -1;
   }
 #else
-  UNUSED(core_id);
+  ITHREAD_UNUSED(core_id);
 #endif
   return 1;
 }


### PR DESCRIPTION
- UNUSED macro had warning of redefinition
- Renamed UNUSED to ITHREAD_UNUSED