### PR TITLE
Rename macro. Add support for aarch32 builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ This library provides abstractions for threading functions, mutex, and semaphore
   ```      
     cmake --install ${buildTree}
   ```
+### **Building for aarch32 Linux**
+1. Create a buildtree
+  ```
+    toolchainPath=<Path to aarch32 toolchain>
+    libThreadPath=<Path to libfgs repo>
+    buildTree=<Name of buildTree folder>
+    installPath=<Path to install folder>
+    cd ${libThreadPath}
+    PATH=${toolchainPath}:${PATH} cmake . -B ${buildTree}\
+    -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchains/aarch32_toolchain.cmake\
+    -DCMAKE_INSTALL_LIBDIR:STRING=${installPath}\
+    -DCMAKE_INSTALL_INCLUDEDIR:STRING=${installPath}
+  ```
+2. Build using buildtree
+  ```      
+    cmake --build ${buildTree}
+  ```
+3. Install (Installs to 'lib' folder)
+  ```      
+    cmake --install ${buildTree}
+  ```
 ### **Building for x86-64 Windows**
 1. Open git bash
 2. Create a buildtree

--- a/cmake/toolchains/aarch32_toolchain.cmake
+++ b/cmake/toolchains/aarch32_toolchain.cmake
@@ -1,0 +1,7 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch32)
+
+# Modify these variables with paths to appropriate compilers that can produce
+# armv7 targets
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -30,6 +30,9 @@ function(defineInterfaces)
     if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
       target_compile_options("${projName}CompileOptions"
                              INTERFACE -march=armv8-a)
+    elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch32")
+      target_compile_options("${projName}CompileOptions"
+                             INTERFACE -march=armv7-a -mfpu=neon)
     else()
       target_compile_options("${projName}CompileOptions"
                              INTERFACE -march=native)

--- a/include/ithread.h
+++ b/include/ithread.h
@@ -40,7 +40,7 @@
 
 #include <stdint.h>
 
-#define UNUSED(x) ((void) x)
+#define ITHREAD_UNUSED(x) ((void) x)
 
 typedef void *(*ThreadFxn)(void *);
 

--- a/src/ithread.c
+++ b/src/ithread.c
@@ -76,7 +76,7 @@ int32_t ithread_create(void *thread_handle, void *attribute, ThreadFxn strt, voi
   HANDLE *ppv_thread_handle;
   HANDLE  thread_handle_value;
 
-  UNUSED(attribute);
+  ITHREAD_UNUSED(attribute);
 
   if (0 == thread_handle)
     return -1;
@@ -98,7 +98,7 @@ int32_t ithread_join(void *thread_handle, void **val_ptr)
   HANDLE *ppv_thread_handle;
   HANDLE  thread_handle_value;
 
-  UNUSED(val_ptr);
+  ITHREAD_UNUSED(val_ptr);
 
   if (0 == thread_handle)
     return -1;
@@ -234,7 +234,7 @@ int32_t ithread_sem_init(void *sem, int32_t pshared, uint32_t value)
   HANDLE *sem_handle = (HANDLE *) sem;
   HANDLE  sem_handle_value;
 
-  UNUSED(pshared);
+  ITHREAD_UNUSED(pshared);
 
   if (0 == sem)
     return -1;
@@ -308,14 +308,14 @@ int32_t ithread_sem_destroy(void *sem)
 
 int32_t ithread_set_affinity(int32_t core_id)
 {
-  UNUSED(core_id);
+  ITHREAD_UNUSED(core_id);
 
   return 1;
 }
 
 void ithread_set_name(char *pc_thread_name)
 {
-  UNUSED(pc_thread_name);
+  ITHREAD_UNUSED(pc_thread_name);
 
   return;
 }
@@ -334,14 +334,14 @@ uint32_t ithread_get_mutex_lock_size(void)
 
 int32_t ithread_create(void *thread_handle, void *attribute, ThreadFxn strt, void *argument)
 {
-  UNUSED(attribute);
+  ITHREAD_UNUSED(attribute);
   return pthread_create((pthread_t *) thread_handle, NULL, strt, argument);
 }
 
 int32_t ithread_join(void *thread_handle, void **val_ptr)
 {
   pthread_t *pthread_handle = (pthread_t *) thread_handle;
-  UNUSED(val_ptr);
+  ITHREAD_UNUSED(val_ptr);
   return pthread_join(*pthread_handle, NULL);
 }
 
@@ -407,7 +407,7 @@ uint32_t ithread_get_sem_struct_size(void)
 int32_t ithread_sem_init(void *sem, int32_t pshared, uint32_t value)
 {
   mac_sem *mac_sem = sem;
-  UNUSED(pshared);
+  ITHREAD_UNUSED(pshared);
 
   dispatch_semaphore_t *dispatch_sem = &mac_sem->disp_sem;
 
@@ -434,7 +434,7 @@ int32_t ithread_sem_wait(void *sem)
 int32_t ithread_sem_destroy(void *sem)
 {
   mac_sem *mac_sem = sem;
-  // UNUSED(sem);
+  // ITHREAD_UNUSED(sem);
 
   dispatch_release(mac_sem->disp_sem);
   return 1;
@@ -473,7 +473,7 @@ void ithread_set_name(char *pc_thread_name)
 #ifndef WIN32
 #ifndef QNX
 #ifndef IOS
-  UNUSED(pc_thread_name);
+  ITHREAD_UNUSED(pc_thread_name);
 #endif
 #endif
 #endif
@@ -495,7 +495,7 @@ int32_t ithread_set_affinity(int32_t core_id)
 
 #elif SYSCALL_AFFINITY
   int32_t i4_sys_res;
-  UNUSED(core_id);
+  ITHREAD_UNUSED(core_id);
 
   pid_t pid = gettid();
 
@@ -505,7 +505,7 @@ int32_t ithread_set_affinity(int32_t core_id)
     return -1;
   }
 #else
-  UNUSED(core_id);
+  ITHREAD_UNUSED(core_id);
 #endif
   return 1;
 }


### PR DESCRIPTION
- Rename macro UNUSED to ITHREAD_UNUSED
- Add aarch32 flags
- Add a toolchain file for aarch32
- Update README with build instructions for aarch32